### PR TITLE
Fix parser in case of symbol contains number with a space

### DIFF
--- a/flameshow/parsers/stackcollapse_parser.py
+++ b/flameshow/parsers/stackcollapse_parser.py
@@ -26,7 +26,7 @@ class StackCollapseParser:
 
         self.highest = 0
         self.id_store: Dict[int, Frame] = {self.root._id: self.root}
-        self.line_regex = r"(.*?) (\d+)"
+        self.line_regex = r"(.*?) (\d+)$"
         self.line_matcher = re.compile(self.line_regex)
 
     def idgenerator(self):


### PR DESCRIPTION
Example: https://gist.github.com/azat/6f98f6d8cac5fad58e07fd913f9cf4f1