### PR TITLE
Fix invisible square [frame] in stackcollapse frame view

### DIFF
--- a/flameshow/models.py
+++ b/flameshow/models.py
@@ -88,7 +88,7 @@ class Frame:
                     Text.assemble(
                         (" ", Style(bgcolor=frame.display_color.rich_color)),
                         " ",
-                        Text.from_markup(line),
+                        line,
                     )
                 )
             frame = frame.parent

--- a/flameshow/parsers/stackcollapse_parser.py
+++ b/flameshow/parsers/stackcollapse_parser.py
@@ -3,6 +3,8 @@ import os
 import re
 from typing import Dict
 
+from rich.text import Text
+
 from flameshow.models import Frame, Profile, SampleType
 
 logger = logging.getLogger(__name__)
@@ -12,7 +14,7 @@ class StackCollapseFrame(Frame):
     def render_one_frame_detail(
         self, frame, sample_index: int, sample_unit: str
     ):
-        return [f"{frame.name}\n"]
+        return [Text(f"{frame.name}\n")]
 
 
 class StackCollapseParser:

--- a/flameshow/pprof_parser/parser.py
+++ b/flameshow/pprof_parser/parser.py
@@ -11,6 +11,8 @@ import gzip
 import logging
 from typing import Dict, List
 
+from rich.text import Text
+
 from flameshow.models import Frame, Profile, SampleType
 
 from . import profile_pb2
@@ -112,7 +114,7 @@ class PprofFrame(Frame):
             f"  [grey37]{frame.line.function.filename}, [b]line"
             f" {frame.line.line_no}[/b][/grey37]\n"
         )
-        return [line1, line2]
+        return [Text.from_markup(line1), Text.from_markup(line2)]
 
     @property
     def title(self) -> str:


### PR DESCRIPTION
Square brackets indicate markup and we import frame names as markup.

* Before:

```
│   main
│
│   __libc_start_main
│   _start
│   rs-1brc
│   root
```

* After:

```
│   main
│   [libc.so.6]
│   __libc_start_main
│   _start
│   rs-1brc
│   root
```